### PR TITLE
Fix dependencies for example project

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,8 @@
 project('example', 'c', 'vala')
 
 glib_dep = dependency('glib-2.0')
-gio_dep = dependency('glib-2.0')
-gobject_dep = dependency('glib-2.0')
+gio_dep = dependency('gio-2.0')
+gobject_dep = dependency('gobject-2.0')
 soup_dep = dependency('libsoup-2.4')
 vsgi_dep = dependency('vsgi-0.3', fallback: ['valum', 'vsgi'])
 valum_dep = dependency('valum-0.3', fallback: ['valum', 'valum'])


### PR DESCRIPTION
The example project fails to build because it lists the glib dependency twice instead of glib, gio and gobject. Without gio, compilation fails with lots of errors like "error: The type name `GLib.IOError' could not be found".